### PR TITLE
Widening symfony/yaml lib dependency to allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "doctrine/dbal": "^2.8",
-        "symfony/yaml": "^4.1"
+        "symfony/yaml": "^4.1 | ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7",


### PR DESCRIPTION
This makes schema-version-control usable in a Symfony 5 application.