### PR TITLE
Fixing issue with quoted primary keys

### DIFF
--- a/src/Utils/SchemaNormalizer.php
+++ b/src/Utils/SchemaNormalizer.php
@@ -39,7 +39,7 @@ class SchemaNormalizer
         $tableDesc = [];
 
         if ($table->hasPrimaryKey()) {
-            $pk_columns = $table->getPrimaryKeyColumns();
+            $pk_columns = $table->getPrimaryKey()->getUnquotedColumns();
         } else {
             $pk_columns = [];
         }


### PR DESCRIPTION
This one-line change fixes an issue in some very specific cases (namely using Oracle 11 with lower case primary keys).

In this case, the return of `$table->getPrimaryKeyColumns()` is "quoted" (i.e. something like `['"id"']`)
But the return of `$column->getName()` is unquoted.
As a result, the comparison line 53 (`in_array($column->getName(), $pk_columns)`) will always fail and exported tables will not have a primary key at all.

Here, we are making sure we use unquoted columns for primary keys.