### PR TITLE
Adding a branch alias on dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
     },
     "archive": {
         "exclude": ["tests", "*phpunit.xml"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
The development version is on the master branch.
But your repository has a "master" and a "1.x" branch.
As it turns out, the 1.x branch is "behind" the currently tagged branch that all come from "master".

I was currently trying to get the fixes from #7 in TDBM.

I updated my composer.json like this:

```
        "brain-diminished/schema-version-control": "^1.0.5",
```

Since there is no 1.0.5 version tagged yet, I thought it would fallback to dev-master, but it actually picked the 1.x branch (which is late).

This PR adds a "branch-alias" (https://getcomposer.org/doc/articles/aliases.md#branch-alias) to composer.json so that "master" branch becomes the dev branch of 1.0.x releases.
In parallel of merging this, I think you should completely delete the 1.X branch.